### PR TITLE
Add OTEL to http clients by default

### DIFF
--- a/keyfunc/okta/okta.go
+++ b/keyfunc/okta/okta.go
@@ -7,6 +7,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/sovietaced/okta-jwt-verifier/metadata"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"io"
 	"log/slog"
 	"net/http"
@@ -72,7 +73,12 @@ func WithBackgroundCtx(ctx context.Context) Option {
 
 func defaultOptions() *Options {
 	opts := &Options{}
-	WithHttpClient(http.DefaultClient)(opts)
+
+	httpClient := http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	}
+
+	WithHttpClient(&httpClient)(opts)
 	withClock(clock.New())(opts)
 	WithCacheTtl(DefaultCacheTtl)(opts)
 	WithFetchStrategy(Lazy)(opts)

--- a/metadata/okta/okta.go
+++ b/metadata/okta/okta.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/benbjohnson/clock"
 	"github.com/sovietaced/okta-jwt-verifier/metadata"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -70,7 +71,11 @@ func WithBackgroundCtx(ctx context.Context) Option {
 
 func defaultOptions() *Options {
 	opts := &Options{}
-	WithHttpClient(http.DefaultClient)(opts)
+
+	httpClient := http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	}
+	WithHttpClient(&httpClient)(opts)
 	withClock(clock.New())(opts)
 	WithCacheTtl(DefaultCacheTtl)(opts)
 	WithFetchStrategy(Lazy)(opts)


### PR DESCRIPTION
Wrap HTTP client transport with OTEL for traces/metrics by default.